### PR TITLE
fix: polish session layout consistency and feedback UX

### DIFF
--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -1,6 +1,6 @@
 import { Component, signal, inject } from '@angular/core';
 import { RouterOutlet, Router, RouterLink } from '@angular/router';
-import { ThemeService, Theme } from './services/theme.service';
+import { ThemeService } from './services/theme.service';
 import { AuthService } from './services/auth.service';
 import { CommonModule } from '@angular/common';
 
@@ -28,24 +28,24 @@ import { CommonModule } from '@angular/common';
           @if (authService.isAuthenticated()) {
             <div class="flex items-center gap-3 pr-6 border-r border-black/10 dark:border-white/10 hidden md:flex">
               <div class="flex flex-col items-end">
-                <span class="text-[8px] font-black text-gray-400 uppercase tracking-widest leading-none mb-1">Authenticated_Operator</span>
+                <span class="text-[8px] font-black text-gray-400 uppercase tracking-widest leading-none mb-1">Signed in as</span>
                 <span class="text-[10px] font-black uppercase text-black dark:text-white leading-none">{{ authService.currentUser()?.username }}</span>
               </div>
-              <button (click)="logout()" class="px-3 py-2 min-h-10 border border-black dark:border-white text-[10px] font-black uppercase hover:bg-black hover:text-white dark:hover:bg-white dark:hover:text-black transition-all active:scale-95 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black dark:focus-visible:outline-white">Disconnect</button>
+              <button (click)="logout()" class="px-3 py-2 min-h-10 border border-black dark:border-white text-[10px] font-black uppercase hover:bg-black hover:text-white dark:hover:bg-white dark:hover:text-black transition-all active:scale-95 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black dark:focus-visible:outline-white">Sign out</button>
             </div>
           }
 
           <!-- Instrument-style Theme Slider -->
           <div class="flex items-center gap-3">
-            <span class="text-[9px] font-black uppercase tracking-widest text-gray-400">Mode</span>
-            <div class="relative w-30 h-8 bg-gray-100 dark:bg-black border border-black dark:border-white p-0.5 flex">
+            <span class="text-[9px] font-black uppercase tracking-widest text-gray-400">Theme</span>
+            <div class="relative w-[10.5rem] h-11 bg-gray-100 dark:bg-black border border-black dark:border-white p-0.5 flex">
               <div 
                 class="absolute top-0.5 bottom-0.5 w-[calc(33.33%-1px)] bg-black dark:bg-white transition-all duration-300 ease-out z-0"
                 [style.transform]="getSliderPosition()"
               ></div>
-              <button (click)="themeService.setTheme('light')" class="relative z-10 flex-1 text-[10px] font-black uppercase text-center transition-colors focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-black dark:focus-visible:outline-white" [class.text-white]="themeService.theme() === 'light'" [class.dark:text-black]="themeService.theme() === 'light'">Light</button>
-              <button (click)="themeService.setTheme('dark')" class="relative z-10 flex-1 text-[10px] font-black uppercase text-center transition-colors focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-black dark:focus-visible:outline-white" [class.text-white]="themeService.theme() === 'dark'" [class.dark:text-black]="themeService.theme() === 'dark'">Dark</button>
-              <button (click)="themeService.setTheme('system')" class="relative z-10 flex-1 text-[10px] font-black uppercase text-center transition-colors focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-black dark:focus-visible:outline-white" [class.text-white]="themeService.theme() === 'system'" [class.dark:text-black]="themeService.theme() === 'system'">Auto</button>
+              <button (click)="themeService.setTheme('light')" class="relative z-10 flex-1 min-h-10 text-[10px] font-black uppercase text-center transition-colors focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-black dark:focus-visible:outline-white" [class.text-white]="themeService.theme() === 'light'" [class.dark:text-black]="themeService.theme() === 'light'">Light</button>
+              <button (click)="themeService.setTheme('dark')" class="relative z-10 flex-1 min-h-10 text-[10px] font-black uppercase text-center transition-colors focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-black dark:focus-visible:outline-white" [class.text-white]="themeService.theme() === 'dark'" [class.dark:text-black]="themeService.theme() === 'dark'">Dark</button>
+              <button (click)="themeService.setTheme('system')" class="relative z-10 flex-1 min-h-10 text-[10px] font-black uppercase text-center transition-colors focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-black dark:focus-visible:outline-white" [class.text-white]="themeService.theme() === 'system'" [class.dark:text-black]="themeService.theme() === 'system'">Auto</button>
             </div>
           </div>
         </div>

--- a/frontend/src/app/pages/admin/admin.ts
+++ b/frontend/src/app/pages/admin/admin.ts
@@ -14,12 +14,18 @@ import { InputComponent } from '../../components/input/input';
       <div class="flex-shrink-0 flex flex-col lg:flex-row justify-between items-end gap-6 border-b-2 border-black dark:border-white pb-6 mb-8">
         <div class="flex-grow">
           <h2 class="text-4xl font-black text-gray-900 dark:text-white uppercase tracking-tighter leading-none">Operator Registry</h2>
-          <p class="text-[10px] font-black text-gray-400 dark:text-gray-500 uppercase tracking-[0.3em] mt-2">System Access Control</p>
+          <p class="text-[10px] font-black text-gray-400 dark:text-gray-500 uppercase tracking-[0.3em] mt-2">Manage user access and roles</p>
         </div>
         
         <div class="flex items-end gap-4">
-          <app-button class="h-9 whitespace-nowrap active:scale-95 transition-transform" (onClick)="openCreateModal()">+ Add New Operator</app-button>
+          <app-button class="h-9 whitespace-nowrap active:scale-95 transition-transform" (onClick)="openCreateModal()">+ Add operator</app-button>
         </div>
+
+        @if (loadError()) {
+          <div class="w-full lg:w-auto border border-red-600 bg-red-50 dark:bg-red-900/20 px-3 py-2">
+            <p class="text-[10px] font-bold text-red-700 dark:text-red-300">{{ loadError() }}</p>
+          </div>
+        }
       </div>
 
       <div class="flex-grow overflow-y-auto custom-scrollbar border-2 border-black dark:border-white bg-white dark:bg-gray-900">
@@ -36,8 +42,8 @@ import { InputComponent } from '../../components/input/input';
           <tbody class="divide-y divide-black/10 dark:divide-white/10">
             @for (user of users(); track user.id) {
               <tr class="hover:bg-black/5 dark:hover:bg-white/5 transition-colors">
-                <td class="px-4 py-3 font-mono font-bold">{{ user.username }}</td>
-                <td class="px-4 py-3 text-gray-500 dark:text-gray-400">{{ user.email }}</td>
+                <td class="px-4 py-3 font-mono font-bold truncate max-w-[220px]" [title]="user.username">{{ user.username }}</td>
+                <td class="px-4 py-3 text-gray-500 dark:text-gray-400 truncate max-w-[280px]" [title]="user.email">{{ user.email }}</td>
                 <td class="px-4 py-3 text-center">
                   @if (user.is_admin) {
                     <span class="px-1.5 py-0.5 bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300 text-[9px] font-black uppercase ring-1 ring-blue-500/20">Admin</span>
@@ -60,23 +66,31 @@ import { InputComponent } from '../../components/input/input';
       </div>
 
       <!-- Create User Modal -->
-      <app-modal [isOpen]="isModalOpen()" title="Provision New Operator" (close)="isModalOpen.set(false)">
+      <app-modal [isOpen]="isModalOpen()" title="Add operator" (close)="isModalOpen.set(false)">
         <div class="space-y-4">
+          @if (formError()) {
+            <p role="alert" class="text-[10px] font-bold text-red-700 dark:text-red-300">{{ formError() }}</p>
+          }
+
+          @if (formSuccess()) {
+            <p aria-live="polite" class="text-[10px] font-bold text-green-700 dark:text-green-300">{{ formSuccess() }}</p>
+          }
+
           <app-input 
             label="Username" 
-            placeholder="OPERATOR_NAME" 
+            placeholder="operator_name" 
             [value]="newUser().username"
             (valueChange)="updateNewUser('username', $event)"
           />
           <app-input 
-            label="System Email" 
+            label="Email" 
             type="email"
             placeholder="operator@system.internal" 
             [value]="newUser().email"
             (valueChange)="updateNewUser('email', $event)"
           />
           <app-input 
-            label="Initial Access Key" 
+            label="Temporary password" 
             type="password"
             placeholder="••••••••" 
             [value]="newUser().password"
@@ -91,13 +105,15 @@ import { InputComponent } from '../../components/input/input';
               (change)="toggleAdmin($event)"
               class="w-4 h-4 accent-black dark:accent-white"
             >
-            <label for="is_admin" class="text-[10px] font-black uppercase tracking-widest text-gray-500">Elevate to System Administrator</label>
+            <label for="is_admin" class="text-[10px] font-black uppercase tracking-widest text-gray-500">Grant admin access</label>
           </div>
         </div>
         
         <div footer class="flex justify-end gap-3">
-          <app-button variant="secondary" (onClick)="isModalOpen.set(false)">Abort</app-button>
-          <app-button [disabled]="!isValid()" (onClick)="createUser()">Establish Record</app-button>
+          <app-button variant="secondary" (onClick)="isModalOpen.set(false)">Cancel</app-button>
+          <app-button [disabled]="isSubmitting() || !isValid()" (onClick)="createUser()">
+            {{ isSubmitting() ? 'Creating...' : 'Create user' }}
+          </app-button>
         </div>
       </app-modal>
     </div>
@@ -108,7 +124,11 @@ export class AdminDashboardComponent implements OnInit {
   
   users = signal<any[]>([]);
   isModalOpen = signal(false);
-  
+  loadError = signal('');
+  formError = signal('');
+  formSuccess = signal('');
+  isSubmitting = signal(false);
+
   newUser = signal({
     username: '',
     email: '',
@@ -121,11 +141,19 @@ export class AdminDashboardComponent implements OnInit {
   }
 
   loadUsers() {
-    this.api.getUsers().subscribe(users => this.users.set(users));
+    this.loadError.set('');
+    this.api.getUsers().subscribe({
+      next: (users) => this.users.set(users),
+      error: (err) => {
+        this.loadError.set(err.error?.error || 'Could not load users. Refresh and try again.');
+      }
+    });
   }
 
   openCreateModal() {
     this.newUser.set({ username: '', email: '', password: '', is_admin: false });
+    this.formError.set('');
+    this.formSuccess.set('');
     this.isModalOpen.set(true);
   }
 
@@ -143,12 +171,21 @@ export class AdminDashboardComponent implements OnInit {
   }
 
   createUser() {
+    this.formError.set('');
+    this.formSuccess.set('');
+    this.isSubmitting.set(true);
+
     this.api.createOperator(this.newUser()).subscribe({
       next: () => {
+        this.isSubmitting.set(false);
+        this.formSuccess.set('User created successfully.');
         this.isModalOpen.set(false);
         this.loadUsers();
       },
-      error: (err) => alert(err.error?.error || 'Provisioning failed')
+      error: (err) => {
+        this.isSubmitting.set(false);
+        this.formError.set(err.error?.error || 'Could not create user. Check the details and try again.');
+      }
     });
   }
 }

--- a/frontend/src/app/pages/login/login.ts
+++ b/frontend/src/app/pages/login/login.ts
@@ -18,20 +18,20 @@ import { CardComponent } from '../../components/card/card';
             System Login
           </h1>
           <p class="text-xs font-bold text-gray-500 uppercase tracking-widest">
-            Identity_Verification_Protocol
+            Sign in with your username or email.
           </p>
         </div>
 
         <form (submit)="onSubmit($event)" class="space-y-4">
           <app-input
-            label="Identifier (Email or Username)"
-            placeholder="SYSTEM_ID_001"
+            label="Username or email"
+            placeholder="you@example.com"
             [value]="identifier()"
             (valueChange)="identifier.set($event)"
           />
 
           <app-input
-            label="Access Key"
+            label="Password"
             type="password"
             placeholder="••••••••"
             [value]="password()"
@@ -50,14 +50,14 @@ import { CardComponent } from '../../components/card/card';
               class="w-full"
               [disabled]="isLoading()"
             >
-              {{ isLoading() ? 'AUTHENTICATING...' : 'ESTABLISH_SESSION' }}
+              {{ isLoading() ? 'Signing in...' : 'Sign in' }}
             </app-button>
           </div>
         </form>
 
         <div class="mt-8 pt-6 border-t border-black/5 flex justify-between items-center opacity-30">
-          <span class="text-[8px] font-mono text-gray-400">AUTH_LEVEL: RESTRICTED</span>
-          <span class="text-[8px] font-mono text-gray-400">ENCRYPTION: AES-256</span>
+          <span class="text-[8px] font-mono text-gray-400">Secure access</span>
+          <span class="text-[8px] font-mono text-gray-400">Encrypted connection</span>
         </div>
       </app-card>
     </div>
@@ -76,7 +76,7 @@ export class LoginComponent {
   onSubmit(event: Event) {
     event.preventDefault();
     if (!this.identifier() || !this.password()) {
-      this.error.set('Credentials Required');
+      this.error.set('Enter both username/email and password.');
       return;
     }
 
@@ -92,7 +92,7 @@ export class LoginComponent {
         this.router.navigateByUrl(returnUrl);
       },
       error: (err) => {
-        this.error.set(err.error?.error || 'Authentication Failed');
+        this.error.set(err.error?.error || 'Sign-in failed. Check your credentials and try again.');
         this.isLoading.set(false);
       }
     });

--- a/frontend/src/app/pages/session-detail/session-detail.ts
+++ b/frontend/src/app/pages/session-detail/session-detail.ts
@@ -13,7 +13,7 @@ import { ModalComponent } from '../../components/modal/modal';
   standalone: true,
   imports: [CommonModule, RouterLink, ButtonComponent, CardComponent, InputComponent, ModalComponent],
   template: `
-    <div class="flex flex-col h-full max-w-[1600px] mx-auto overflow-hidden px-2 sm:px-6 animate-in fade-in duration-700 ease-out">
+    <div class="w-full flex flex-col min-h-full max-w-[1600px] mx-auto overflow-y-auto px-2 sm:px-6 animate-in fade-in duration-700 ease-out">
     @if (session()) {
       <!-- 1. MISSION CONTROL HEADER (OMNIPRESENT) -->
       <div class="flex-shrink-0 bg-white dark:bg-gray-900 border-b-2 border-black dark:border-white pb-4 pt-3 relative z-[100] space-y-4">
@@ -23,7 +23,7 @@ import { ModalComponent } from '../../components/modal/modal';
           <div class="flex items-center gap-3">
             <a routerLink="/sessions" class="flex items-center gap-1.5 px-2 py-1 border border-black/10 hover:bg-black/5 transition-colors text-[10px] font-black uppercase tracking-widest text-gray-400 mr-2 group">
               <svg class="w-3 h-3 group-hover:-translate-x-0.5 transition-transform" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3"><path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" /></svg>
-              Manifest
+Sessions
             </a>
             <div class="bg-black text-white dark:bg-white dark:text-black px-2 py-1 font-mono text-lg font-black tracking-tighter shadow-[2px_2px_0px_0px_rgba(0,0,0,0.1)] animate-in slide-in-from-left-2 duration-500">
               SESS_{{ session()?.id }}
@@ -32,7 +32,7 @@ import { ModalComponent } from '../../components/modal/modal';
               <h2 class="text-3xl md:text-4xl font-black text-gray-900 dark:text-white uppercase tracking-tighter leading-none break-words animate-in slide-in-from-left-4 duration-700">
                 {{ session()?.title }}
               </h2>
-              <span class="text-[9px] font-black uppercase tracking-widest text-black/30 dark:text-white/30 mt-1">Creator: {{ session()?.creator_name || 'ANONYMOUS' }}</span>
+              <span class="text-[9px] font-black uppercase tracking-widest text-black/30 dark:text-white/30 mt-1">Created by: {{ session()?.creator_name || 'ANONYMOUS' }}</span>
             </div>
           </div>
           
@@ -49,11 +49,11 @@ import { ModalComponent } from '../../components/modal/modal';
             
             <div class="flex bg-white dark:bg-gray-900 border border-black dark:border-white p-0.5 shadow-[2px_2px_0px_0px_rgba(0,0,0,0.1)]">
               @if (session()?.status === 'planned') {
-                <app-button size="sm" class="font-bold active:scale-95 transition-transform" (onClick)="openMetaModal()">Begin Session</app-button>
+                <app-button size="sm" class="font-bold active:scale-95 transition-transform" (onClick)="openMetaModal()">Start session</app-button>
               } @else if (session()?.status === 'in-progress') {
-                <app-button variant="danger" size="sm" class="font-bold active:scale-95 transition-transform" (onClick)="moveToDebriefing()">End Logging</app-button>
+                <app-button variant="danger" size="sm" class="font-bold active:scale-95 transition-transform" (onClick)="moveToDebriefing()">Stop logging</app-button>
               } @else if (session()?.status === 'debriefing') {
-                <app-button size="sm" class="font-bold active:scale-95 transition-transform" (onClick)="completeSession()">Finalize Manifest</app-button>
+                <app-button size="sm" class="font-bold active:scale-95 transition-transform" (onClick)="completeSession()">Complete session</app-button>
               }
             </div>
           </div>
@@ -62,22 +62,22 @@ import { ModalComponent } from '../../components/modal/modal';
         <!-- Row 2: Primary Charter (High Visibility) -->
         <div class="flex flex-col md:flex-row gap-4 py-3 px-4 bg-gray-50 dark:bg-gray-800/30 border-x-2 border-y border-black dark:border-white shadow-[inset_4px_0px_0px_0px_rgba(0,0,0,0.1)] transition-all hover:bg-gray-100 dark:hover:bg-gray-800/50 group">
           <div class="flex-grow">
-            <span class="text-[10px] font-black uppercase tracking-[0.3em] text-gray-400 block mb-1 group-hover:text-black dark:group-hover:text-white transition-colors">Primary Charter Protocol</span>
+            <span class="text-[10px] font-black uppercase tracking-[0.3em] text-gray-400 block mb-1 group-hover:text-black dark:group-hover:text-white transition-colors">Session charter</span>
             <h3 class="text-lg md:text-xl font-black text-black dark:text-white leading-tight border-l-4 border-black dark:border-white pl-4 py-1">
               {{ session()?.charter }}
             </h3>
           </div>
           <div class="flex flex-row md:flex-col items-start md:items-end justify-between md:justify-center gap-2 md:min-w-[140px] border-t md:border-t-0 md:border-l border-black/10 pt-2 md:pt-0 md:pl-4">
              <div class="flex flex-col items-start md:items-end">
-               <span class="text-[9px] font-black text-gray-400 uppercase tracking-tighter">Target_Unit</span>
+               <span class="text-[9px] font-black text-gray-400 uppercase tracking-tighter">Machine</span>
                <span class="text-[11px] font-bold text-black dark:text-white font-mono uppercase bg-black/5 dark:bg-white/5 px-1.5 transition-colors group-hover:bg-black/10 dark:group-hover:bg-white/10">{{ session()?.machine_name || 'UNDEFINED' }}</span>
              </div>
              <div class="flex flex-col items-start md:items-end">
-               <span class="text-[9px] font-black text-gray-400 uppercase tracking-tighter">SW_Version</span>
+               <span class="text-[9px] font-black text-gray-400 uppercase tracking-tighter">Software version</span>
                <span class="text-[11px] font-bold text-black dark:text-white font-mono uppercase bg-black/5 dark:bg-white/5 px-1.5 transition-colors group-hover:bg-black/10 dark:group-hover:bg-white/10">{{ session()?.software_version || 'UNDEFINED' }}</span>
              </div>
              <div class="flex flex-col items-start md:items-end">
-               <span class="text-[9px] font-black text-gray-400 uppercase tracking-tighter">Deployment_Date</span>
+               <span class="text-[9px] font-black text-gray-400 uppercase tracking-tighter">Created on</span>
                <span class="text-[11px] font-bold text-gray-400 font-mono">{{ session()?.created_at | date:'yyyy-MM-dd' }}</span>
              </div>
              @if (session()?.status !== 'completed') {
@@ -91,7 +91,7 @@ import { ModalComponent } from '../../components/modal/modal';
           <div class="flex flex-col lg:flex-row gap-3 items-stretch lg:items-end">
             <div class="flex-grow relative">
               <div class="flex justify-between items-center mb-1">
-                  <label class="text-[10px] font-black uppercase tracking-widest text-black/40">Observation Capture</label>
+                  <label class="text-[10px] font-black uppercase tracking-widest text-black/40">New log entry</label>
                   @if (selectedArtifacts().length > 0) {
                     <div class="flex gap-1">
                       @for (art of selectedArtifacts(); track art.id) {
@@ -105,7 +105,7 @@ import { ModalComponent } from '../../components/modal/modal';
               </div>
               <app-input 
                 type="textarea" 
-                [placeholder]="isCaptureLocked() ? 'Capture Buffer Locked - Session Not Active' : 'What are you seeing? Record notes, findings, or issues in real-time...'" 
+                [placeholder]="isCaptureLocked() ? 'Logging is locked because this session is not active.' : 'Describe what you observed (note, finding, or issue)...'" 
                 [value]="logEntry()"
                 (valueChange)="logEntry.set($event)"
                 [disabled]="isCaptureLocked()"
@@ -123,7 +123,7 @@ import { ModalComponent } from '../../components/modal/modal';
                 <button [disabled]="isCaptureLocked()" (click)="logCategory.set('issue')" [class]="'flex-1 px-2 text-[9px] font-bold uppercase border-l border-black dark:border-white transition-all ' + (logCategory() === 'issue' ? 'bg-black text-white dark:bg-white dark:text-black' : 'hover:bg-black/5 dark:hover:bg-white/5')">Issue</button>
               </div>
               <app-button class="font-black uppercase text-[10px] h-9 active:scale-95 transition-transform" [disabled]="isCaptureLocked() || !logEntry() || isSubmittingLog()" (onClick)="submitLog()">
-                Commit Observation
+Add log entry
               </app-button>
             </div>
           </div>
@@ -131,30 +131,21 @@ import { ModalComponent } from '../../components/modal/modal';
       </div>
 
       <!-- 3. MAIN WORK AREA -->
-      <div class="flex-grow overflow-hidden pt-4 pb-2">
-        <div class="grid grid-cols-1 lg:grid-cols-12 gap-6 h-full">
+      <div class="w-full pt-4 pb-6">
+        <div class="w-full grid grid-cols-1 lg:grid-cols-12 gap-6">
           
           <!-- TIMELINE COLUMN -->
-          <div class="order-2 lg:order-1 lg:col-span-5 h-full flex flex-col min-h-0 relative z-10 pr-2">
+          <div class="w-full order-2 lg:order-1 lg:col-span-5 flex flex-col relative z-10 pr-2">
             
             @if (session()?.status === 'planned') {
-              <div class="mb-6 animate-in zoom-in-95 duration-500 flex-shrink-0">
-                <div class="p-6 bg-black text-white dark:bg-white dark:text-black border-2 border-black dark:border-white shadow-[8px_8px_0px_0px_rgba(0,0,0,0.1)]">
-                  <div class="flex items-start space-x-4">
-                    <div class="flex-shrink-0 p-2 bg-white text-black dark:bg-black dark:text-white rounded-none border border-black dark:border-white animate-pulse-slow">
-                      <svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
-                      </svg>
+              <div class="mb-4 animate-in zoom-in-95 duration-500 flex-shrink-0">
+                <div class="p-4 bg-black text-white dark:bg-white dark:text-black border-2 border-black dark:border-white shadow-[6px_6px_0px_0px_rgba(0,0,0,0.1)]">
+                  <div class="flex items-center justify-between gap-4">
+                    <div>
+                      <h4 class="text-base font-black uppercase tracking-tight">Ready to start</h4>
+                      <p class="text-[11px] font-medium opacity-90">Set machine and version details, then begin logging.</p>
                     </div>
-                    <div class="space-y-3">
-                      <h4 class="text-lg font-black uppercase tracking-tight">System Ready for Execution</h4>
-                      <p class="text-xs font-medium leading-relaxed opacity-90">
-                        This session is in the **Planned** state. To begin your exploratory audit, you must first designate the unit (machine or environment) under test.
-                      </p>
-                      <div class="pt-2">
-                        <app-button variant="secondary" size="sm" class="font-bold !bg-white !text-black border-black active:scale-95 transition-transform" (onClick)="openMetaModal()">Execute Start Protocol</app-button>
-                      </div>
-                    </div>
+                    <app-button variant="secondary" size="sm" class="font-bold !bg-white !text-black border-black active:scale-95 transition-transform whitespace-nowrap" (onClick)="openMetaModal()">Start session setup</app-button>
                   </div>
                 </div>
               </div>
@@ -162,7 +153,7 @@ import { ModalComponent } from '../../components/modal/modal';
 
             @if (session()?.status === 'debriefing' || session()?.status === 'completed') {
               <div class="mb-6 animate-in slide-in-from-left-4 duration-500 flex-shrink-0">
-                <app-card title="Post-Testing Summary">
+                <app-card title="Debrief summary">
                   @if (session()?.status === 'debriefing') {
                     <div class="space-y-3">
                       <app-input 
@@ -172,18 +163,29 @@ import { ModalComponent } from '../../components/modal/modal';
                         (valueChange)="debriefSummary.set($event)"
                         class="transition-all focus-within:ring-2 focus-within:ring-black dark:focus-within:ring-white"
                       />
+
+                      @if (debriefError()) {
+                        <p role="alert" class="text-[10px] font-bold text-red-700 dark:text-red-300">{{ debriefError() }}</p>
+                      }
+
+                      @if (debriefSavedMessage()) {
+                        <p aria-live="polite" class="text-[10px] font-bold text-green-700 dark:text-green-300">{{ debriefSavedMessage() }}</p>
+                      }
+
                       <div class="flex justify-end">
-                        <app-button class="font-bold active:scale-95 transition-transform" (onClick)="saveDebriefSummary()">Save Report</app-button>
+                        <app-button [disabled]="isSavingDebrief()" class="font-bold active:scale-95 transition-transform" (onClick)="saveDebriefSummary()">
+                          {{ isSavingDebrief() ? 'Saving...' : 'Save summary' }}
+                        </app-button>
                       </div>
                     </div>
                   } @else {
-                    <p class="text-sm text-gray-700 dark:text-gray-300 font-medium whitespace-pre-wrap leading-relaxed">{{ session()?.debrief_summary || 'No report filed.' }}</p>
+                    <p class="text-sm text-gray-700 dark:text-gray-300 font-medium whitespace-pre-wrap leading-relaxed">{{ session()?.debrief_summary || 'No summary added yet.' }}</p>
                   }
                 </app-card>
               </div>
             }
 
-            <app-card title="Execution Log" class="animate-in fade-in slide-in-from-bottom-4 duration-700 delay-150 fill-mode-both flex-grow min-h-0" contentClass="flex flex-col h-full">
+            <app-card title="Session log" class="animate-in fade-in slide-in-from-bottom-4 duration-700 delay-150 fill-mode-both min-h-[12rem]" contentClass="flex flex-col h-full">
               <div header-actions>
                 <button 
                   (click)="toggleLogSort()" 
@@ -200,7 +202,7 @@ import { ModalComponent } from '../../components/modal/modal';
                 </button>
               </div>
               <div class="flow-root overflow-y-auto custom-scrollbar flex-grow min-h-0 pr-2">
-                <ul role="list" class="-mb-8">
+                <ul role="list" class="pb-2">
                   @for (log of sortedLogs(); track log.id; let last = $last; let i = $index) {
                     <li class="animate-in slide-in-from-left-4 fade-in duration-500 fill-mode-both" [style.animation-delay]="(i * 50) + 'ms'">
                       <div class="relative pb-8">
@@ -256,9 +258,9 @@ import { ModalComponent } from '../../components/modal/modal';
           </div>
 
           <!-- TOOLBELT COLUMN (Artifacts & Evidence) -->
-          <div class="order-1 lg:order-2 lg:col-span-7 h-full flex flex-col min-h-0 relative z-30 animate-in fade-in slide-in-from-right-4 duration-700 delay-300 fill-mode-both">
-            <div class="flex-grow overflow-hidden flex flex-col min-h-0">
-              <app-card title="Artifact Evidence Pool" class="h-full flex-grow" contentClass="flex flex-col h-full">
+          <div class="w-full order-1 lg:order-2 lg:col-span-7 flex flex-col relative z-30 animate-in fade-in slide-in-from-right-4 duration-700 delay-300 fill-mode-both">
+            <div class="flex flex-col">
+              <app-card title="Artifacts" class="h-full flex-grow" contentClass="flex flex-col h-full">
                 <div class="flex flex-col h-full space-y-4">
                   <div class="flex justify-between items-center flex-shrink-0">
                     <div class="flex gap-1.5">
@@ -299,11 +301,11 @@ import { ModalComponent } from '../../components/modal/modal';
                         </div>
 
                         @if (getLinkedLogsForArtifact(art.id).length > 0) {
-                          <div class="absolute -top-1.5 -left-1.5 bg-black text-white dark:bg-white dark:text-black px-1.5 py-0.5 text-[8px] font-black ring-1 ring-white shadow-sm animate-in zoom-in-75 duration-300">Cited</div>
+                          <div class="absolute -top-1.5 -left-1.5 bg-black text-white dark:bg-white dark:text-black px-1.5 py-0.5 text-[8px] font-black ring-1 ring-white shadow-sm animate-in zoom-in-75 duration-300">Linked</div>
                         }
                       </div>
                     } @empty {
-                      <p class="col-span-full text-center text-gray-400 text-xs font-bold uppercase py-12 animate-in fade-in duration-1000">Buffer Empty</p>
+                      <p class="col-span-full text-center text-gray-400 text-xs font-bold uppercase py-12 animate-in fade-in duration-1000">No artifacts uploaded yet</p>
                     }
                   </div>
                 </div>
@@ -314,7 +316,7 @@ import { ModalComponent } from '../../components/modal/modal';
       </div>
     } @else {
       <div class="flex justify-center py-40">
-        <span class="text-sm font-black uppercase tracking-[0.4em] animate-pulse">Initializing Manifest...</span>
+        <span class="text-sm font-black uppercase tracking-[0.4em] animate-pulse">Loading session...</span>
       </div>
     }
 
@@ -346,9 +348,9 @@ import { ModalComponent } from '../../components/modal/modal';
         </div>
       </div>
       <div footer class="flex justify-end gap-3">
-        <app-button variant="secondary" class="font-bold active:scale-95 transition-transform" (onClick)="isMetaModalOpen.set(false)">Abort</app-button>
+        <app-button variant="secondary" class="font-bold active:scale-95 transition-transform" (onClick)="isMetaModalOpen.set(false)">Cancel</app-button>
         <app-button [disabled]="!machineName() || !softwareVersion()" class="font-bold active:scale-95 transition-transform" (onClick)="saveMetadata()">
-          {{ session()?.status === 'planned' ? 'Execute Start' : 'Save Changes' }}
+          {{ session()?.status === 'planned' ? 'Start session' : 'Save changes' }}
         </app-button>
       </div>
     </app-modal>
@@ -356,7 +358,7 @@ import { ModalComponent } from '../../components/modal/modal';
     <!-- Link Artifacts Modal -->
     <app-modal [isOpen]="isLinkModalOpen()" title="Link Artifacts" (close)="isLinkModalOpen.set(false)">
       <div class="space-y-4 animate-in slide-in-from-bottom-2 duration-300">
-        <p class="text-[11px] font-bold uppercase tracking-widest text-gray-400">[Select Relevant Citations]</p>
+        <p class="text-[11px] font-bold uppercase tracking-widest text-gray-400">Select artifacts to link</p>
         <div class="grid grid-cols-3 gap-2 max-h-60 overflow-y-auto p-1">
           @for (art of artifacts(); track art.id) {
             <div 
@@ -369,8 +371,8 @@ import { ModalComponent } from '../../components/modal/modal';
         </div>
       </div>
       <div footer class="flex justify-end gap-3">
-        <app-button variant="secondary" class="font-bold active:scale-95 transition-transform" (onClick)="isLinkModalOpen.set(false)">Dismiss</app-button>
-        <app-button class="font-bold active:scale-95 transition-transform" (onClick)="linkArtifacts()">Save Citations</app-button>
+        <app-button variant="secondary" class="font-bold active:scale-95 transition-transform" (onClick)="isLinkModalOpen.set(false)">Cancel</app-button>
+        <app-button class="font-bold active:scale-95 transition-transform" (onClick)="linkArtifacts()">Save links</app-button>
       </div>
     </app-modal>
 
@@ -385,24 +387,24 @@ import { ModalComponent } from '../../components/modal/modal';
               {{ previewContent() }}
             } @else {
               <div class="flex justify-center py-12">
-                <span class="animate-pulse font-bold">Fetching Buffer...</span>
+                <span class="animate-pulse font-bold">Loading file preview...</span>
               </div>
             }
           </div>
         } @else {
           <div class="py-20 text-center space-y-6">
             <svg class="h-20 w-20 mx-auto text-gray-200 dark:text-gray-700" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
-            <p class="text-gray-400 font-bold uppercase tracking-widest text-[11px]">File type unsupported</p>
-            <app-button class="font-bold active:scale-95 transition-transform" (onClick)="downloadArtifact(previewArtifact())">Download Archive</app-button>
+            <p class="text-gray-400 font-bold uppercase tracking-widest text-[11px]">Preview not available for this file type</p>
+            <app-button class="font-bold active:scale-95 transition-transform" (onClick)="downloadArtifact(previewArtifact())">Download file</app-button>
           </div>
         }
       </div>
       <div footer>
         <div class="flex justify-between items-center w-full">
           <div class="text-[10px] font-bold uppercase text-gray-400">
-            REF:{{ previewArtifact()?.id }}
+File ID: {{ previewArtifact()?.id }}
           </div>
-          <app-button variant="secondary" class="font-bold active:scale-95 transition-transform" (onClick)="isPreviewModalOpen.set(false)">Dismiss</app-button>
+          <app-button variant="secondary" class="font-bold active:scale-95 transition-transform" (onClick)="isPreviewModalOpen.set(false)">Close</app-button>
         </div>
       </div>
     </app-modal>
@@ -443,6 +445,9 @@ export class SessionDetailComponent implements OnInit, OnDestroy {
   logEntry = signal('');
   logCategory = signal('note');
   debriefSummary = signal('');
+  debriefSavedMessage = signal('');
+  debriefError = signal('');
+  isSavingDebrief = signal(false);
   isUploading = signal(false);
   isSubmittingLog = signal(false);
   
@@ -472,7 +477,6 @@ export class SessionDetailComponent implements OnInit, OnDestroy {
   isPreviewModalOpen = signal(false);
   previewArtifact = signal<any>(null);
   previewContent = signal<string | null>(null);
-  isDebriefingMode = signal(false);
 
   toggleLogSort() {
     this.logSortOrder.set(this.logSortOrder() === 'ASC' ? 'DESC' : 'ASC');
@@ -568,16 +572,30 @@ export class SessionDetailComponent implements OnInit, OnDestroy {
       this.logs.set(session.logs);
       this.artifacts.set(session.artifacts);
       this.debriefSummary.set(session.debrief_summary || '');
-      this.hasMoreLogs.set(false); 
+      this.hasMoreLogs.set(false);
       if (session.machine_name) this.machineName.set(session.machine_name);
       if (session.software_version) this.softwareVersion.set(session.software_version);
     });
   }
 
   saveDebriefSummary() {
+    if (this.isSavingDebrief()) return;
+
     const id = this.session().id;
-    this.api.updateSession(id, { debrief_summary: this.debriefSummary() }).subscribe(updated => {
-      this.session.update(s => ({ ...s, ...updated }));
+    this.debriefSavedMessage.set('');
+    this.debriefError.set('');
+    this.isSavingDebrief.set(true);
+
+    this.api.updateSession(id, { debrief_summary: this.debriefSummary() }).subscribe({
+      next: (updated) => {
+        this.session.update(s => ({ ...s, ...updated }));
+        this.debriefSavedMessage.set('Summary saved.');
+        this.isSavingDebrief.set(false);
+      },
+      error: (err) => {
+        this.debriefError.set(err.error?.error || 'Could not save summary. Please try again.');
+        this.isSavingDebrief.set(false);
+      }
     });
   }
 

--- a/frontend/src/app/pages/session-list/session-list.ts
+++ b/frontend/src/app/pages/session-list/session-list.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, signal, inject, EffectRef, effect, computed } from '@angular/core';
+import { Component, OnInit, signal, inject, computed } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterLink } from '@angular/router';
 import { ApiService } from '../../services/api';
@@ -22,7 +22,7 @@ import { debounceTime, distinctUntilChanged, Subject, switchMap, of } from 'rxjs
       <div class="flex-shrink-0 flex flex-col lg:flex-row justify-between items-end gap-6 border-b-2 border-black dark:border-white pb-6 mb-8">
         <div class="flex-grow">
           <h2 class="text-4xl font-black text-gray-900 dark:text-white uppercase tracking-tighter leading-none">Session Archive</h2>
-          <p class="text-[10px] font-black text-gray-400 dark:text-gray-500 uppercase tracking-[0.3em] mt-2">Exploratory Testing Manifest</p>
+          <p class="text-[10px] font-black text-gray-400 dark:text-gray-500 uppercase tracking-[0.3em] mt-2">Track and review exploratory test sessions</p>
         </div>
         
         <div class="flex flex-wrap items-end gap-4 w-full lg:w-auto">
@@ -50,6 +50,12 @@ import { debounceTime, distinctUntilChanged, Subject, switchMap, of } from 'rxjs
           <app-button class="h-9 whitespace-nowrap active:scale-95 transition-transform" (onClick)="openCreateModal()">+ New Manifest</app-button>
         </div>
       </div>
+
+      @if (listError()) {
+        <div class="mb-4 border border-red-600 bg-red-50 dark:bg-red-900/20 px-3 py-2">
+          <p class="text-[10px] font-bold text-red-700 dark:text-red-300">{{ listError() }}</p>
+        </div>
+      }
 
       <div class="flex-grow overflow-y-auto custom-scrollbar border-2 border-black dark:border-white bg-white dark:bg-gray-900 relative">
         <div class="min-w-full inline-block align-middle">
@@ -168,7 +174,7 @@ import { debounceTime, distinctUntilChanged, Subject, switchMap, of } from 'rxjs
                             No sessions match the active filters.
                           </p>
                         </div>
-                        <app-button size="sm" class="active:scale-95 transition-transform" (onClick)="openCreateModal()">+ Initialize New Session</app-button>
+                        <app-button size="sm" class="active:scale-95 transition-transform" (onClick)="openCreateModal()">+ Create session</app-button>
                       </div>
                     </td>
                   </tr>
@@ -182,29 +188,33 @@ import { debounceTime, distinctUntilChanged, Subject, switchMap, of } from 'rxjs
       @if (hasMore()) {
         <div class="flex-shrink-0 flex justify-center pt-6">
           <app-button variant="secondary" size="sm" [disabled]="isLoading()" (onClick)="loadMore()" class="active:scale-95 transition-transform">
-            {{ isLoading() ? 'Loading...' : 'Fetch More Data' }}
+            {{ isLoading() ? 'Loading...' : 'Load more sessions' }}
           </app-button>
         </div>
       }
 
       <app-modal 
         [isOpen]="isModalOpen()" 
-        title="Initialize New Session" 
+        title="Create session" 
         (close)="isModalOpen.set(false)"
       >
         <div class="space-y-4 animate-in slide-in-from-bottom-2 duration-300">
+          @if (createError()) {
+            <p role="alert" class="text-[10px] font-bold text-red-700 dark:text-red-300">{{ createError() }}</p>
+          }
+
           <!-- Metadata Reuse Section - Refined hierarchy -->
           <div class="p-3 border-2 border-black dark:border-white space-y-3 bg-gray-50 dark:bg-gray-800/20">
             <div class="flex justify-between items-center border-b border-black/10 dark:border-white/10 pb-1.5">
-              <label class="text-[9px] font-black uppercase tracking-[0.2em] text-gray-400 leading-none">Template Protocol</label>
+              <label class="text-[9px] font-black uppercase tracking-[0.2em] text-gray-400 leading-none">Use previous session details</label>
               @if (selectedTemplate()) {
-                <button (click)="clearTemplate()" class="text-[9px] font-black text-red-500 hover:underline uppercase transition-all active:scale-90">Abort Reuse</button>
+                <button (click)="clearTemplate()" class="text-[9px] font-black text-red-500 hover:underline uppercase transition-all active:scale-90">Clear</button>
               }
             </div>
             
             @if (!selectedTemplate()) {
               <app-input 
-                placeholder="Search historical manifest..." 
+                placeholder="Search past sessions..." 
                 [value]="templateSearchQuery()"
                 (valueChange)="onTemplateSearch($event)"
                 class="!mb-0 !text-[10px]"
@@ -224,42 +234,42 @@ import { debounceTime, distinctUntilChanged, Subject, switchMap, of } from 'rxjs
               }
             } @else {
               <div class="flex items-center justify-between bg-black text-white dark:bg-white dark:text-black px-2 py-1.5 text-[10px] font-black uppercase animate-in zoom-in-95 duration-200">
-                <span class="truncate">Active: {{ selectedTemplate().title }}</span>
-                <span class="text-[8px] font-mono opacity-70">LOCKED</span>
+                <span class="truncate">Using: {{ selectedTemplate().title }}</span>
+                <span class="text-[8px] font-mono opacity-70">Template active</span>
               </div>
             }
           </div>
 
           <app-input 
-            label="Session Identifier" 
+            label="Session title" 
             placeholder="Navigation Audit" 
             [value]="newSession().title"
             (valueChange)="updateNewSession('title', $event)"
           />
           <div class="space-y-1">
             <app-input 
-              label="Mission Charter" 
+              label="Charter" 
               type="textarea"
-              placeholder="Define goal and approach parameters..." 
+              placeholder="Describe what this session should cover..." 
               [value]="newSession().charter"
               (valueChange)="updateNewSession('charter', $event)"
             />
           </div>
           <div class="grid grid-cols-2 gap-4">
             <app-input 
-              label="Target Unit" 
+              label="Machine" 
               placeholder="Test-VM-01" 
               [value]="newSession().machine_name"
               (valueChange)="updateNewSession('machine_name', $event)"
             />
             <div>
-              <label class="block text-xs font-black uppercase tracking-widest text-gray-900 dark:text-gray-100 mb-1.5">SW Version</label>
+              <label class="block text-xs font-black uppercase tracking-widest text-gray-900 dark:text-gray-100 mb-1.5">Software version</label>
               <select
                 [value]="newSession().software_version"
                 (change)="updateNewSession('software_version', $any($event.target).value)"
                 class="w-full px-3 py-2 min-h-11 bg-white dark:bg-gray-900 border-2 border-gray-900 dark:border-gray-100 rounded-none focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black dark:focus-visible:outline-white focus:bg-gray-50 dark:focus:bg-gray-800 dark:text-white sm:text-sm transition-all"
               >
-                <option value="" disabled>Select version</option>
+                <option value="" disabled>Select a version</option>
                 @for (v of availableVersions(); track v) {
                   <option [value]="v">{{ v }}</option>
                 }
@@ -267,15 +277,15 @@ import { debounceTime, distinctUntilChanged, Subject, switchMap, of } from 'rxjs
             </div>
           </div>
           <app-input 
-            label="Timebox (Min)" 
+            label="Timebox (minutes)" 
             type="number"
             [value]="newSession().duration_minutes.toString()"
             (valueChange)="updateNewSession('duration_minutes', $event)"
           />
         </div>
         <div footer class="flex justify-end gap-3">
-          <app-button variant="secondary" (onClick)="isModalOpen.set(false)" class="active:scale-95 transition-transform">Abort</app-button>
-          <app-button [disabled]="!isValid()" (onClick)="createSession()" class="active:scale-95 transition-transform">Execute</app-button>
+          <app-button variant="secondary" (onClick)="isModalOpen.set(false)" class="active:scale-95 transition-transform">Cancel</app-button>
+          <app-button [disabled]="!isValid()" (onClick)="createSession()" class="active:scale-95 transition-transform">Create session</app-button>
         </div>
       </app-modal>
     </div>
@@ -319,6 +329,8 @@ export class SessionListComponent implements OnInit {
   sortOrder = signal<'ASC' | 'DESC'>('DESC');
   isLoading = signal(false);
   hasMore = signal(false);
+  listError = signal('');
+  createError = signal('');
 
   currentLatestVersion = computed(() => {
     if (this.availableVersions().length === 0) return null;
@@ -355,13 +367,17 @@ export class SessionListComponent implements OnInit {
   }
 
   loadVersions() {
-    this.api.getVersions().subscribe(versions => {
-      this.availableVersions.set(versions);
-      
-      // Validate stored version
-      const stored = this.selectedVersion();
-      if (stored && !versions.includes(stored)) {
-        this.onVersionChange(''); // Reset if version no longer exists
+    this.api.getVersions().subscribe({
+      next: (versions) => {
+        this.availableVersions.set(versions);
+
+        const stored = this.selectedVersion();
+        if (stored && !versions.includes(stored)) {
+          this.onVersionChange('');
+        }
+      },
+      error: () => {
+        this.listError.set('Could not load versions. Refresh and try again.');
       }
     });
   }
@@ -423,19 +439,27 @@ export class SessionListComponent implements OnInit {
 
   loadSessions() {
     this.isLoading.set(true);
+    this.listError.set('');
+
     this.api.getSessions(
-      this.searchQuery(), 
-      this.limit, 
-      this.offset(), 
-      this.sortBy(), 
+      this.searchQuery(),
+      this.limit,
+      this.offset(),
+      this.sortBy(),
       this.sortOrder(),
       this.selectedVersion() || undefined
-    ).subscribe(res => {
-      const current = this.sessions();
-      this.sessions.set([...current, ...res.sessions]);
-      this.total.set(res.pagination.total);
-      this.hasMore.set(this.sessions().length < res.pagination.total);
-      this.isLoading.set(false);
+    ).subscribe({
+      next: (res) => {
+        const current = this.sessions();
+        this.sessions.set([...current, ...res.sessions]);
+        this.total.set(res.pagination.total);
+        this.hasMore.set(this.sessions().length < res.pagination.total);
+        this.isLoading.set(false);
+      },
+      error: (err) => {
+        this.isLoading.set(false);
+        this.listError.set(err.error?.error || 'Could not load sessions. Check your connection and try again.');
+      }
     });
   }
 
@@ -453,6 +477,7 @@ export class SessionListComponent implements OnInit {
       machine_name: '',
       duration_minutes: 60,
     });
+    this.createError.set('');
     this.selectedTemplate.set(null);
     this.templateSearchQuery.set('');
     this.historicalSessions.set([]);
@@ -472,14 +497,16 @@ export class SessionListComponent implements OnInit {
   }
 
   createSession() {
+    this.createError.set('');
+
     this.api.createSession(this.newSession()).subscribe({
       next: () => {
         this.isModalOpen.set(false);
-        this.loadVersions(); // Refresh versions list in case new one was added
+        this.loadVersions();
         this.resetAndLoad();
       },
       error: (err) => {
-        alert(err.error?.error || 'Failed to create session');
+        this.createError.set(err.error?.error || 'Could not create session. Check the form and try again.');
       }
     });
   }

--- a/frontend/src/app/pages/setup-account/setup-account.ts
+++ b/frontend/src/app/pages/setup-account/setup-account.ts
@@ -18,20 +18,20 @@ import { CardComponent } from '../../components/card/card';
             Account Setup
           </h1>
           <p class="text-xs font-bold text-gray-500 uppercase tracking-widest leading-relaxed">
-            Personalize your operator credentials to complete system entry.
+            Set your account details to finish first-time setup.
           </p>
         </div>
 
         <form (submit)="onSubmit($event)" class="space-y-4">
           <app-input
-            label="Operator Username"
+            label="Username"
             placeholder="e.g. j_doe"
             [value]="username()"
             (valueChange)="username.set($event)"
           />
 
           <app-input
-            label="Internal Email"
+            label="Email"
             type="email"
             placeholder="operator@system.internal"
             [value]="email()"
@@ -40,7 +40,7 @@ import { CardComponent } from '../../components/card/card';
 
           <div class="pt-2 border-t border-black/5">
             <app-input
-              label="New Access Key"
+              label="New password"
               type="password"
               placeholder="••••••••"
               [value]="password()"
@@ -48,7 +48,7 @@ import { CardComponent } from '../../components/card/card';
             />
 
             <app-input
-              label="Confirm Access Key"
+              label="Confirm password"
               type="password"
               placeholder="••••••••"
               [value]="confirmPassword()"
@@ -68,14 +68,14 @@ import { CardComponent } from '../../components/card/card';
               class="w-full"
               [disabled]="isLoading()"
             >
-              {{ isLoading() ? 'SYNCHRONIZING...' : 'FINALIZE_SETUP' }}
+              {{ isLoading() ? 'Saving...' : 'Finish setup' }}
             </app-button>
           </div>
         </form>
 
         <div class="mt-8 pt-6 border-t border-black/5 flex justify-between items-center opacity-30">
-          <span class="text-[8px] font-mono text-gray-400">STATE: PENDING_INITIALIZATION</span>
-          <span class="text-[8px] font-mono text-gray-400">SECURITY: FORCED_RESET</span>
+          <span class="text-[8px] font-mono text-gray-400">First-time setup</span>
+          <span class="text-[8px] font-mono text-gray-400">Password reset required</span>
         </div>
       </app-card>
     </div>
@@ -96,12 +96,12 @@ export class AccountSetupComponent {
     event.preventDefault();
     
     if (!this.username() || !this.email() || !this.password()) {
-      this.error.set('All fields are mandatory');
+      this.error.set('Fill in all fields to continue.');
       return;
     }
 
     if (this.password() !== this.confirmPassword()) {
-      this.error.set('Keys do not match');
+      this.error.set('Passwords do not match.');
       return;
     }
 
@@ -117,7 +117,7 @@ export class AccountSetupComponent {
         this.router.navigate(['/sessions']);
       },
       error: (err) => {
-        this.error.set(err.error?.error || 'Setup Failed');
+        this.error.set(err.error?.error || 'Setup failed. Please review your details and try again.');
         this.isLoading.set(false);
       }
     });

--- a/frontend/src/app/pages/versions/versions.ts
+++ b/frontend/src/app/pages/versions/versions.ts
@@ -12,7 +12,7 @@ import { ButtonComponent } from '../../components/button/button';
     <div class="h-full flex flex-col overflow-hidden px-2 sm:px-6 py-6 animate-in fade-in duration-700 ease-out">
       <div class="flex-shrink-0 border-b-2 border-black dark:border-white pb-6 mb-6">
         <h2 class="text-4xl font-black text-gray-900 dark:text-white uppercase tracking-tighter leading-none">Version Catalog</h2>
-        <p class="text-[10px] font-black text-gray-400 dark:text-gray-500 uppercase tracking-[0.3em] mt-2">Selectable Test Object Versions</p>
+        <p class="text-[10px] font-black text-gray-400 dark:text-gray-500 uppercase tracking-[0.3em] mt-2">Manage selectable software versions</p>
       </div>
 
       <div class="flex-shrink-0 border-2 border-black dark:border-white p-4 mb-6 bg-white dark:bg-gray-900">
@@ -21,7 +21,7 @@ import { ButtonComponent } from '../../components/button/button';
         </p>
 
         <app-input
-          label="Add Version"
+          label="Add version"
           placeholder="v1.2.3"
           [value]="newVersion()"
           [disabled]="isSubmitting()"
@@ -80,7 +80,7 @@ import { ButtonComponent } from '../../components/button/button';
               </tr>
             } @empty {
               <tr>
-                <td colspan="3" class="px-4 py-16 text-center text-[10px] font-black uppercase text-gray-400">No selectable versions configured</td>
+                <td colspan="3" class="px-4 py-16 text-center text-[10px] font-black uppercase text-gray-400">No selectable versions yet</td>
               </tr>
             }
           </tbody>


### PR DESCRIPTION
## Summary
This PR adds final polish and hardening updates focused on session detail consistency, feedback states, and copy clarity.

## What changed
- Fixed session-detail layout clipping and ratio inconsistencies across:
  - `/sessions/5` (planned)
  - `/sessions/4` (completed)
  - `/sessions/2` (debriefing)
- Refined planned-state callout to a compact banner so Session Log remains visible in common desktop viewports
- Added explicit debrief save feedback:
  - loading state (`Saving...`)
  - success message (`Summary saved.`)
  - inline error state on failure
  - double-submit prevention
- Hardened admin and session list flows with inline error handling and improved action states
- Improved focus visibility and control sizing on key interactive controls
- Clarified UX copy across login, setup, sessions, admin, and versions pages while preserving core visual style

## Validation
- `frontend`: `npm run build` passes
- Visual checks performed via Playwright screenshots for referenced pages and states

## Notes
- This change is focused on polish/resilience and does not alter the core visual identity
