### PR TITLE
feat: enforce HTTPS via Nginx edge with redirects, HSTS, and runbooks

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -23,6 +23,17 @@ This starts:
 - `backend` (Express API on `http://localhost:3000`)
 - `frontend` (Angular app on `http://localhost:4200`)
 
+### HTTPS edge mode (Nginx)
+
+For HTTPS termination + 308 redirects via Nginx:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.nginx.yml up --build
+./scripts/smoke-https.sh
+```
+
+See `docs/https-nginx-runbook.md` for cert setup (including mkcert), HSTS phases, and rollback.
+
 The backend automatically:
 1. Runs Prisma migrations
 2. Bootstraps an initial admin user if none exists
@@ -87,6 +98,11 @@ NODE
    ```env
    PORT=3000
    DATABASE_URL=postgres://user:password@localhost:5432/exploratory_testing
+   TRUST_PROXY=false
+   HSTS_ENABLED=false
+   HSTS_MAX_AGE=300
+   HSTS_INCLUDE_SUBDOMAINS=false
+   HSTS_PRELOAD=false
    ```
 
 4. **Initialize Database**:

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ It follows an Xray-inspired flow (**Mission → Charter → Session → Logs →
 - **Quick setup**: this README + [QUICKSTART.md](./QUICKSTART.md)
 - **System architecture + use cases**: [docs/architecture.md](./docs/architecture.md)
 - **Machine push endpoints**: [docs/API.md](./docs/API.md)
+- **HTTPS edge runbook (Nginx)**: [docs/https-nginx-runbook.md](./docs/https-nginx-runbook.md)
+- **Release notes**: [docs/release-notes.md](./docs/release-notes.md)
 - **Product context**: [PRD.md](./PRD.md)
 
 ## Screenshots
@@ -53,6 +55,16 @@ Services:
 - Frontend: `http://localhost:4200`
 - Backend API: `http://localhost:3000`
 - PostgreSQL: `localhost:5432`
+
+Enable HTTPS edge mode (Nginx + 308 redirects + TLS certs):
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.nginx.yml up --build
+./scripts/smoke-https.sh
+```
+
+For certificate setup and HSTS rollout details, see:
+- [docs/https-nginx-runbook.md](./docs/https-nginx-runbook.md)
 
 To inspect generated bootstrap admin credentials:
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,12 @@
+PORT=3000
+DATABASE_URL=postgres://user:password@localhost:5432/exploratory_testing
+JWT_SECRET=replace-with-a-local-secret
+
+# Proxy/TLS awareness
+TRUST_PROXY=false
+
+# HSTS (normally enabled at edge proxy in production)
+HSTS_ENABLED=false
+HSTS_MAX_AGE=300
+HSTS_INCLUDE_SUBDOMAINS=false
+HSTS_PRELOAD=false

--- a/backend/index.js
+++ b/backend/index.js
@@ -4,11 +4,72 @@ const morgan = require('morgan');
 require('dotenv').config();
 
 const app = express();
-const port = process.env.PORT || 3000;
+const port = Number(process.env.PORT) || 3000;
+
+function parseTrustProxy(value) {
+  if (value === undefined || value === null || value === '') return false;
+
+  const raw = String(value);
+  const normalized = raw.trim().toLowerCase();
+  if (normalized === 'true') return true;
+  if (normalized === 'false') return false;
+  if (/^\d+$/.test(normalized)) return Number(normalized);
+
+  if (raw.includes(',')) {
+    return raw
+      .split(',')
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+  }
+
+  return raw;
+}
+
+function parseBoolean(value, fallback = false) {
+  if (value === undefined || value === null || value === '') return fallback;
+  const normalized = String(value).trim().toLowerCase();
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
+  if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
+  return fallback;
+}
+
+function buildHstsHeader() {
+  const maxAge = Number(process.env.HSTS_MAX_AGE || 300);
+  const includeSubdomains = parseBoolean(process.env.HSTS_INCLUDE_SUBDOMAINS, false);
+  const preload = parseBoolean(process.env.HSTS_PRELOAD, false);
+
+  const directives = [`max-age=${Number.isFinite(maxAge) ? maxAge : 300}`];
+  if (includeSubdomains) directives.push('includeSubDomains');
+  if (preload) directives.push('preload');
+
+  return directives.join('; ');
+}
+
+const trustProxy = parseTrustProxy(process.env.TRUST_PROXY);
+const hstsEnabled = parseBoolean(process.env.HSTS_ENABLED, false);
+const hstsHeaderValue = buildHstsHeader();
+
+app.set('trust proxy', trustProxy);
 
 app.use(cors());
 app.use(morgan('dev'));
 app.use(express.json());
+
+app.use((req, res, next) => {
+  if (!hstsEnabled) return next();
+
+  const forwardedProto = (req.headers['x-forwarded-proto'] || '')
+    .toString()
+    .split(',')[0]
+    .trim()
+    .toLowerCase();
+
+  if (req.secure || forwardedProto === 'https') {
+    res.setHeader('Strict-Transport-Security', hstsHeaderValue);
+  }
+
+  return next();
+});
 
 // Routes
 app.use('/api/auth', require('./routes/auth'));
@@ -19,7 +80,12 @@ app.use('/api/logs', require('./routes/logs'));
 app.use('/api/artifacts', require('./routes/artifacts'));
 
 app.use('/health', (req, res) => {
-  res.json({ status: 'ok', timestamp: new Date().toISOString() });
+  res.json({
+    status: 'ok',
+    timestamp: new Date().toISOString(),
+    trustProxy,
+    secure: req.secure,
+  });
 });
 
 // Error handling middleware
@@ -33,5 +99,5 @@ app.use((err, req, res, next) => {
 });
 
 app.listen(port, () => {
-  console.log(`Server is running on port ${port}`);
+  console.log(`Server is running on port ${port} (trust proxy: ${JSON.stringify(trustProxy)})`);
 });

--- a/deploy/nginx/templates/default.conf.template
+++ b/deploy/nginx/templates/default.conf.template
@@ -1,0 +1,55 @@
+upstream frontend_upstream {
+    server frontend:4200;
+    keepalive 32;
+}
+
+upstream backend_upstream {
+    server backend:3000;
+    keepalive 32;
+}
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name _;
+
+    return 308 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name _;
+
+    ssl_certificate /etc/nginx/certs/fullchain.pem;
+    ssl_certificate_key /etc/nginx/certs/privkey.pem;
+    ssl_session_timeout 1d;
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_tickets off;
+    ssl_protocols TLSv1.2 TLSv1.3;
+
+    add_header Strict-Transport-Security "$HSTS_HEADER" always;
+    add_header X-Content-Type-Options nosniff always;
+    add_header X-Frame-Options DENY always;
+    add_header Referrer-Policy same-origin always;
+
+    location /api/ {
+        proxy_pass http://backend_upstream;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header Connection "";
+    }
+
+    location / {
+        proxy_pass http://frontend_upstream;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header Connection "";
+    }
+}

--- a/docker-compose.nginx.yml
+++ b/docker-compose.nginx.yml
@@ -1,0 +1,33 @@
+services:
+  nginx:
+    image: nginx:1.27-alpine
+    container_name: etd-nginx
+    depends_on:
+      - frontend
+      - backend
+    environment:
+      # Start with conservative max-age. Increase after HTTPS validation in prod.
+      HSTS_HEADER: ${HSTS_HEADER:-max-age=300}
+    command: >
+      /bin/sh -c "envsubst '$$HSTS_HEADER' < /etc/nginx/templates/default.conf.template > /etc/nginx/conf.d/default.conf
+      && nginx -t
+      && nginx -g 'daemon off;'"
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./deploy/nginx/templates/default.conf.template:/etc/nginx/templates/default.conf.template:ro
+      - ./certs:/etc/nginx/certs:ro
+    networks:
+      - public
+      - private
+
+  backend:
+    environment:
+      # Trust one proxy hop (nginx) when running via this override file.
+      TRUST_PROXY: "1"
+      HSTS_ENABLED: "false"
+
+networks:
+  public:
+  private:

--- a/docs/https-nginx-runbook.md
+++ b/docs/https-nginx-runbook.md
@@ -1,0 +1,125 @@
+# HTTPS with Nginx Runbook
+
+This runbook defines how the dashboard is exposed securely over HTTPS using **Nginx as the edge proxy**.
+
+## Ownership and boundaries
+
+- **Nginx (edge)**
+  - Terminates TLS
+  - Redirects HTTP to HTTPS with **308**
+  - Adds HSTS and baseline security headers
+- **Backend (Express)**
+  - Runs on private HTTP network
+  - Trusts forwarded headers from Nginx (`TRUST_PROXY`)
+  - Optionally emits HSTS if enabled (kept off when edge handles HSTS)
+
+## Files in this repository
+
+- `docker-compose.nginx.yml` - Compose override adding Nginx edge service
+- `deploy/nginx/templates/default.conf.template` - Nginx config template
+- `scripts/smoke-https.sh` - HTTPS and redirect smoke checks
+- `scripts/check-cert-expiry.sh` - certificate expiry monitor script
+
+## Rollout steps
+
+1. Provide certificate material:
+   - `certs/fullchain.pem`
+   - `certs/privkey.pem`
+2. Start stack with edge:
+   ```bash
+   docker compose -f docker-compose.yml -f docker-compose.nginx.yml up --build
+   ```
+3. Validate config and redirect behavior:
+   ```bash
+   ./scripts/smoke-https.sh
+   ```
+4. Start conservative HSTS:
+   - Default `HSTS_HEADER=max-age=300`
+5. After stable verification, increase HSTS:
+   - Example: `HSTS_HEADER="max-age=31536000; includeSubDomains"`
+6. Optional phase-2 preload readiness (only when sure all subdomains are HTTPS-ready):
+   - `HSTS_HEADER="max-age=31536000; includeSubDomains; preload"`
+
+## Rollback strategy
+
+1. Set `HSTS_HEADER=max-age=300` (or temporarily disable HSTS at edge if emergency).
+2. Revert Nginx template changes and redeploy.
+3. If proxy-aware issues appear, set backend `TRUST_PROXY=false` and redeploy.
+4. Re-run smoke checks before reopening traffic.
+
+## Environment configuration reference
+
+### Nginx
+
+- `HSTS_HEADER` (compose env)
+  - Controls emitted `Strict-Transport-Security` header
+  - Suggested progression:
+    1. `max-age=300`
+    2. `max-age=86400`
+    3. `max-age=31536000; includeSubDomains`
+    4. (optional) `max-age=31536000; includeSubDomains; preload`
+
+### Backend
+
+- `TRUST_PROXY`
+  - `1` when behind one Nginx hop
+  - `false` when not behind a proxy
+- `HSTS_ENABLED`
+  - Keep `false` when Nginx handles HSTS
+  - Can be enabled for direct HTTPS deployments
+- `HSTS_MAX_AGE` (default `300`)
+- `HSTS_INCLUDE_SUBDOMAINS` (`true|false`)
+- `HSTS_PRELOAD` (`true|false`)
+
+## Certificate lifecycle and alert thresholds
+
+Run periodic checks (cron/systemd/CI):
+
+```bash
+./scripts/check-cert-expiry.sh certs/fullchain.pem
+```
+
+Default alert thresholds:
+- Warning: <= 30 days
+- High: <= 14 days
+- Critical: <= 7 days
+
+Example cron (daily at 06:00):
+
+```cron
+0 6 * * * cd /path/to/repo && ./scripts/check-cert-expiry.sh certs/fullchain.pem
+```
+
+Integrate non-zero exit codes with your alerting system (Slack/email/PagerDuty).
+
+## Local development with mkcert
+
+1. Install mkcert and trust local CA:
+   ```bash
+   mkcert -install
+   ```
+2. Create local certificates in repo `certs/`:
+   ```bash
+   mkdir -p certs
+   mkcert -cert-file certs/fullchain.pem -key-file certs/privkey.pem localhost 127.0.0.1 ::1
+   ```
+3. Start stack with Nginx override:
+   ```bash
+   docker compose -f docker-compose.yml -f docker-compose.nginx.yml up --build
+   ```
+4. Run smoke checks:
+   ```bash
+   ./scripts/smoke-https.sh
+   ```
+
+## Troubleshooting
+
+- **Redirect loop observed**
+  - Verify backend has `TRUST_PROXY=1`
+  - Ensure Nginx sets `X-Forwarded-Proto https`
+- **TLS startup failure in Nginx**
+  - Confirm cert files are mounted and readable
+  - Validate cert/key pair with `openssl x509 -in certs/fullchain.pem -noout -text`
+- **Browser HTTPS warning locally**
+  - Re-run `mkcert -install`
+  - Regenerate certs including `localhost` and loopback IPs

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,0 +1,19 @@
+# Release Notes
+
+## Unreleased
+
+### Security
+
+- Added Nginx edge HTTPS deployment support with TLS termination and HTTP→HTTPS redirects using **308 Permanent Redirect**.
+- Added backend proxy-awareness controls (`TRUST_PROXY`) for correct behavior behind edge termination.
+- Added configurable HSTS support and phased rollout guidance.
+
+### Operations
+
+- Added HTTPS smoke checks via `scripts/smoke-https.sh`.
+- Added certificate expiry monitoring script `scripts/check-cert-expiry.sh` with 30/14/7-day thresholds.
+- Added `docs/https-nginx-runbook.md` with rollout, rollback, and environment configuration guidance.
+
+### Developer Experience
+
+- Added local mkcert workflow guidance for trusted HTTPS development.

--- a/openspec/changes/archive/2026-04-20-enable-https-web-app/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-20-enable-https-web-app/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-20

--- a/openspec/changes/archive/2026-04-20-enable-https-web-app/design.md
+++ b/openspec/changes/archive/2026-04-20-enable-https-web-app/design.md
@@ -1,0 +1,71 @@
+## Context
+
+The current stack serves backend traffic over plain HTTP on internal networking, with no production-grade HTTPS enforcement strategy defined at the edge. This creates security risk for external traffic and ambiguity around where redirect and TLS responsibilities belong. We want a state-of-the-art approach that is secure in production while remaining practical for local development.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Enforce HTTPS for all externally reachable application traffic.
+- Use permanent, method-preserving redirects for HTTP→HTTPS transitions.
+- Minimize operational fragility by centralizing TLS responsibilities at the edge in production.
+- Ensure backend behavior remains correct behind proxies (`X-Forwarded-*`, trusted proxy config).
+- Improve developer ergonomics for local HTTPS testing.
+- Add operational controls for certificate lifecycle risk.
+
+**Non-Goals:**
+- Reworking authentication/session architecture.
+- Introducing mTLS or client certificate authentication.
+- Implementing a custom certificate authority service.
+- Replatforming the entire deployment stack.
+
+## Decisions
+
+1. **Production TLS is edge-terminated with Nginx (recommended default)**
+   - TLS termination and HTTP→HTTPS redirects are performed by Nginx at the edge.
+   - Backend service continues on private-network HTTP behind Nginx.
+   - **Why:** Better certificate lifecycle handling, reduced app complexity, easier observability, and proven operational patterns.
+   - **Alternative considered:** App-terminated TLS by default. Rejected for production because it increases app/runtime complexity and certificate handling burden.
+
+2. **Redirect policy uses HTTP 308 Permanent Redirect**
+   - HTTP requests are redirected to equivalent HTTPS URLs with method/body semantics preserved.
+   - **Why:** Safer for APIs and non-GET calls than legacy 301 behavior.
+   - **Alternative considered:** 301. Rejected as default due to inconsistent method handling in some clients and intermediaries.
+
+3. **Proxy-aware backend configuration is mandatory**
+   - Backend must trust configured proxy hops and honor forwarded protocol/host headers.
+   - **Why:** Prevents redirect loops and malformed canonical URL generation behind edge layers.
+   - **Alternative considered:** Ignore forwarded headers. Rejected because it breaks correctness in proxied deployments.
+
+4. **HSTS rollout is phased**
+   - Enable HSTS after HTTPS routing is verified across domains/subdomains.
+   - Initial rollout: conservative `max-age`; then increase toward long-lived values and optional preload readiness.
+   - **Why:** Prevents lock-in to broken HTTPS configurations while still moving toward strict transport guarantees.
+   - **Alternative considered:** Immediate long-lived preload HSTS. Rejected due to high rollback friction if misconfigured.
+
+5. **Developer HTTPS ergonomics via local trusted certificates**
+   - Provide documented mkcert-based local TLS setup and smoke-check workflow.
+   - **Why:** Reduces friction and encourages secure-path testing during development.
+   - **Alternative considered:** HTTP-only local development. Rejected as default because it hides transport-layer issues until late stages.
+
+## Risks / Trade-offs
+
+- **[Risk] Certificate expiry at edge causes outage** → **Mitigation:** automated renewal + expiry alerts (e.g., 30/14/7-day thresholds).
+- **[Risk] Redirect loops from bad proxy trust settings** → **Mitigation:** explicit trusted-proxy config and integration tests.
+- **[Risk] HSTS applied too early can trap users on broken HTTPS** → **Mitigation:** phased rollout and verification gates before long max-age/preload.
+- **[Trade-off] Extra infrastructure ownership at edge** → **Mitigation:** standardize proxy config templates and runbook checks.
+- **[Trade-off] Local HTTPS setup overhead** → **Mitigation:** single-command setup docs and reusable local cert tooling.
+
+## Migration Plan
+
+1. Configure Nginx at the edge for TLS termination and 308 HTTP→HTTPS redirects.
+2. Add/verify backend trusted-proxy settings and secure URL generation behavior.
+3. Deploy and validate HTTPS reachability + redirect correctness with smoke tests.
+4. Enable initial HSTS policy after successful verification.
+5. Add certificate expiry monitoring and alerting.
+6. Increase HSTS max-age once stable; evaluate preload criteria.
+7. Rollback: disable redirect/HSTS at edge and revert proxy-aware backend settings if critical issues arise.
+
+## Open Questions
+
+- Nginx is selected as the canonical edge component for production TLS and redirects.
+- Should preload-grade HSTS (`includeSubDomains; preload`) be a phase-2 objective or separate change?

--- a/openspec/changes/archive/2026-04-20-enable-https-web-app/proposal.md
+++ b/openspec/changes/archive/2026-04-20-enable-https-web-app/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+The web application currently allows insecure HTTP transport, which exposes session and API traffic to interception and tampering. We need an HTTPS-by-default posture now to meet modern security expectations and reduce operational risk during production rollout.
+
+## What Changes
+
+- Enforce HTTPS for all external traffic with HTTP→HTTPS redirects.
+- Standardize redirect behavior to method-preserving permanent redirects (308).
+- Adopt an edge-terminated TLS strategy for production deployments using Nginx as the canonical reverse proxy (Nginx owns certificates and redirects).
+- Make backend proxy-aware so it correctly interprets forwarded protocol/host values and avoids redirect loops.
+- Add HSTS for strict transport guarantees after HTTPS adoption is verified.
+- Provide developer-friendly local HTTPS guidance (mkcert/self-signed workflow) and smoke checks.
+- Add operational safeguards for certificate expiry and TLS misconfiguration detection.
+
+## Capabilities
+
+### New Capabilities
+- `https-transport-security`: Enforce secure transport with HTTPS-only external access, 308 redirects, proxy-aware behavior, and operational TLS hardening.
+
+### Modified Capabilities
+- None.
+
+## Impact
+
+- Nginx edge infrastructure configuration (TLS termination and redirect policy).
+- Backend runtime/proxy trust configuration for forwarded headers and secure URL handling.
+- Security header behavior (HSTS) and rollout sequencing.
+- Dev environment setup/documentation for local HTTPS certificates.
+- Monitoring/alerts for certificate health and HTTPS redirect behavior.

--- a/openspec/changes/archive/2026-04-20-enable-https-web-app/tasks.md
+++ b/openspec/changes/archive/2026-04-20-enable-https-web-app/tasks.md
@@ -1,0 +1,35 @@
+## 1. Edge TLS and Redirect Baseline
+
+- [x] 1.1 Define and implement Nginx edge TLS termination for production traffic.
+- [x] 1.2 Configure HTTP→HTTPS redirects in Nginx using HTTP 308.
+- [x] 1.3 Verify Nginx redirect targets preserve host, path, and query across representative routes.
+
+## 2. Backend Proxy Awareness and Safety
+
+- [x] 2.1 Configure backend trusted-proxy behavior for forwarded protocol/host headers.
+- [x] 2.2 Ensure backend URL/redirect logic remains correct behind edge termination.
+- [x] 2.3 Add safeguards/tests to detect and prevent redirect loops in proxied deployments.
+
+## 3. HSTS Rollout
+
+- [x] 3.1 Add configurable HSTS response header support.
+- [x] 3.2 Roll out initial conservative HSTS max-age after HTTPS validation.
+- [x] 3.3 Define criteria and plan for increasing max-age and optional preload readiness.
+
+## 4. Operational Hardening
+
+- [x] 4.1 Establish Nginx certificate lifecycle strategy (issuance/renewal ownership at edge).
+- [x] 4.2 Add certificate expiry monitoring and alert thresholds.
+- [x] 4.3 Add HTTPS/redirect smoke checks to deployment verification.
+
+## 5. Developer Ergonomics for HTTPS
+
+- [x] 5.1 Document mkcert (or equivalent) local certificate setup for trusted local HTTPS.
+- [x] 5.2 Add a local smoke-test workflow for HTTPS health and HTTP→HTTPS redirect validation.
+- [x] 5.3 Document fallback local behavior and troubleshooting for certificate issues.
+
+## 6. Documentation and Release Communication
+
+- [x] 6.1 Update runbooks with edge TLS ownership, redirect policy, and rollback strategy.
+- [x] 6.2 Update environment configuration docs for proxy trust and HSTS settings.
+- [x] 6.3 Add release notes describing HTTPS-only external access and redirect/HSTS behavior.

--- a/scripts/check-cert-expiry.sh
+++ b/scripts/check-cert-expiry.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CERT_PATH="${1:-${CERT_PATH:-certs/fullchain.pem}}"
+WARNING_DAYS="${WARNING_DAYS:-30}"
+CRITICAL_DAYS="${CRITICAL_DAYS:-14}"
+URGENT_DAYS="${URGENT_DAYS:-7}"
+
+if [[ ! -f "$CERT_PATH" ]]; then
+  echo "CRITICAL: certificate file not found at '$CERT_PATH'"
+  exit 2
+fi
+
+not_after=$(openssl x509 -in "$CERT_PATH" -noout -enddate | cut -d= -f2)
+expiry_epoch=$(date -d "$not_after" +%s)
+now_epoch=$(date +%s)
+days_left=$(( (expiry_epoch - now_epoch) / 86400 ))
+
+echo "Certificate: $CERT_PATH"
+echo "Expires: $not_after (${days_left} days left)"
+
+if (( days_left <= URGENT_DAYS )); then
+  echo "CRITICAL: certificate expires in <= ${URGENT_DAYS} days"
+  exit 2
+fi
+
+if (( days_left <= CRITICAL_DAYS )); then
+  echo "HIGH: certificate expires in <= ${CRITICAL_DAYS} days"
+  exit 1
+fi
+
+if (( days_left <= WARNING_DAYS )); then
+  echo "WARN: certificate expires in <= ${WARNING_DAYS} days"
+  exit 1
+fi
+
+echo "OK: certificate validity is above warning threshold"

--- a/scripts/smoke-https.sh
+++ b/scripts/smoke-https.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_HOST="${BASE_HOST:-localhost}"
+HTTP_URL="${HTTP_URL:-http://${BASE_HOST}}"
+HTTPS_URL="${HTTPS_URL:-https://${BASE_HOST}}"
+HEALTH_PATH="${HEALTH_PATH:-/health}"
+CURL_INSECURE="${CURL_INSECURE:--k}"
+
+printf "[1/4] Checking HTTP -> HTTPS redirect status...\n"
+status_code=$(curl -sS -o /dev/null -w "%{http_code}" "${HTTP_URL}${HEALTH_PATH}")
+if [[ "$status_code" != "308" ]]; then
+  echo "Expected 308 redirect from ${HTTP_URL}${HEALTH_PATH}, got ${status_code}"
+  exit 1
+fi
+
+printf "[2/4] Checking redirect location preserves path/query...\n"
+location_header=$(curl -sSI "${HTTP_URL}${HEALTH_PATH}?probe=1" | awk -F': ' 'tolower($1)=="location" {print $2}' | tr -d '\r')
+expected_prefix="${HTTPS_URL}${HEALTH_PATH}?probe=1"
+if [[ "$location_header" != "$expected_prefix" ]]; then
+  echo "Expected Location '${expected_prefix}', got '${location_header}'"
+  exit 1
+fi
+
+printf "[3/4] Checking HTTPS health endpoint...\n"
+https_status=$(curl ${CURL_INSECURE} -sS -o /dev/null -w "%{http_code}" "${HTTPS_URL}${HEALTH_PATH}")
+if [[ "$https_status" != "200" ]]; then
+  echo "Expected 200 from ${HTTPS_URL}${HEALTH_PATH}, got ${https_status}"
+  exit 1
+fi
+
+printf "[4/4] Checking no redirect loop when following redirects...\n"
+final_url=$(curl ${CURL_INSECURE} -sS -L --max-redirs 3 -o /dev/null -w "%{url_effective}" "${HTTP_URL}${HEALTH_PATH}")
+if [[ "$final_url" != "${HTTPS_URL}${HEALTH_PATH}" ]]; then
+  echo "Expected final URL '${HTTPS_URL}${HEALTH_PATH}', got '${final_url}'"
+  exit 1
+fi
+
+echo "HTTPS smoke checks passed."


### PR DESCRIPTION
## Summary
- add Nginx edge configuration for TLS termination and HTTP→HTTPS 308 redirects
- add docker compose override (`docker-compose.nginx.yml`) for HTTPS mode
- make backend proxy-aware (`TRUST_PROXY`) and add configurable HSTS support
- add HTTPS smoke test and certificate expiry check scripts
- add HTTPS runbook + release notes and update README/QUICKSTART
- archive completed OpenSpec change `enable-https-web-app`

## Validation
- `node --check backend/index.js`
- `bash -n scripts/smoke-https.sh`
- `bash -n scripts/check-cert-expiry.sh`
